### PR TITLE
Update webhook server comment

### DIFF
--- a/webhook_server.py
+++ b/webhook_server.py
@@ -28,7 +28,7 @@ from bot import process_rows
 app = FastAPI()
 
 # ─────────────────────────────────────────────────────────  
-← now a comment
+# Tracks ZPIDs already exported to avoid duplicates
 EXPORTED_ZPIDS: set[str] = set()
 
 


### PR DESCRIPTION
## Summary
- remove stray text from `webhook_server.py`
- add a small comment describing purpose of `EXPORTED_ZPIDS`

## Testing
- `python -m py_compile webhook_server.py` *(fails: invalid character '─')*