### PR TITLE
Add run script and Apify hook docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Zillow Short Sale Bot
+
+This project contains a FastAPI server that processes datasets from Apify and pushes qualifying properties to a Google Sheet.
+
+## Running the server
+
+Use the `run.sh` script to start the webhook server. The script loads environment variables from `.env` if the file exists and then launches `uvicorn` on port `8000`:
+
+```bash
+./run.sh
+```
+
+## Apify integration
+
+Configure your Apify actor to send a POST request to the `/apify-hook` endpoint of this server when your dataset is ready. The webhook should include the dataset ID, either in the JSON body or as a `datasetId` query parameter.
+
+Example JSON body:
+
+```json
+{ "datasetId": "YOUR_DATASET_ID" }
+```
+
+Apify will POST this payload to:
+
+```
+https://<your-server-host>/apify-hook
+```
+
+On receiving the dataset ID, the server will fetch the dataset and process any new rows.
+

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Load environment variables from .env if it exists
+if [ -f ".env" ]; then
+  set -o allexport
+  source .env
+  set +o allexport
+fi
+
+# Start the FastAPI webhook server
+exec uvicorn webhook_server:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- add `run.sh` to start webhook server on port 8000
- document how to run server and how Apify should POST dataset ID to `/apify-hook`

## Testing
- `python -m py_compile webhook_server.py apify_fetcher.py` *(fails: invalid characters in existing files)*