### PR TITLE
Add debug log for follow-up skip timing

### DIFF
--- a/bot_min.py
+++ b/bot_min.py
@@ -1012,7 +1012,11 @@ def _follow_up_pass():
         except Exception:
             continue
 
-        if business_hours_elapsed(ts, now) < FU_HOURS:
+        hrs = business_hours_elapsed(ts, now)
+        if hrs < FU_HOURS:
+            LOG.debug(
+                "FU‑skip row %s – %.2f business hours elapsed", sheet_row, hrs
+            )
             continue
 
         # debug line requested by Yoni


### PR DESCRIPTION
## Summary
- track business hours elapsed since initial contact
- log skipped follow-ups when the FU window hasn't opened yet

## Testing
- `python -m py_compile bot_min.py`

------
https://chatgpt.com/codex/tasks/task_e_686bffdb0d24832a82f81b2a54c8a187