### PR TITLE
Respect end-of-day limit in business_hours_elapsed

### DIFF
--- a/bot_min.py
+++ b/bot_min.py
@@ -213,7 +213,8 @@ def business_hours_elapsed(start_ts: datetime, now: datetime) -> float:
     cur = start_ts
     step = timedelta(minutes=15)
     while cur < now:
-        nxt = min(now, cur + step)
+        end_of_work = cur.replace(hour=WORK_END, minute=0, second=0, microsecond=0)
+        nxt = min(now, cur + step, end_of_work)
         if not _is_weekend(cur) and WORK_START <= cur.hour < WORK_END:
             total += (nxt - cur).total_seconds() / 3600.0
         cur = nxt


### PR DESCRIPTION
## Summary
- ensure daily end time caps the next interval in `business_hours_elapsed`

## Testing
- `python -m py_compile bot_min.py`


------
https://chatgpt.com/codex/tasks/task_e_686c002b38c4832aa34341c7e1152a66