### PR TITLE
Handle end-of-day in business hour calc

### DIFF
--- a/bot_min.py
+++ b/bot_min.py
@@ -216,6 +216,12 @@ def business_hours_elapsed(start_ts: datetime, now: datetime) -> float:
     while cur < now:
         end_of_work = cur.replace(hour=WORK_END, minute=0, second=0, microsecond=0)
         nxt = min(now, cur + step, end_of_work)
+        if nxt == cur:
+            cur = (cur + timedelta(days=1)).replace(
+                hour=WORK_START, minute=0, second=0, microsecond=0
+            )
+            LOG.debug("business_hours_elapsed skipped to next workday")
+            continue
         if not _is_weekend(cur) and WORK_START <= cur.hour < WORK_END:
             total += (nxt - cur).total_seconds() / 3600.0
         cur = nxt


### PR DESCRIPTION
## Summary
- update `business_hours_elapsed` to skip to the next day when no work time remains

## Testing
- `python -m py_compile bot_min.py`

------
https://chatgpt.com/codex/tasks/task_e_686c19b9ba18832a8331c97a2f155145