### PR TITLE
Check for replies in follow-up pass

### DIFF
--- a/bot_min.py
+++ b/bot_min.py
@@ -1007,6 +1007,16 @@ def _follow_up_pass():
         if row[COL_REPLY_FLAG].strip() or row[COL_MANUAL_NOTE].strip():
             continue
 
+        # auto-check for replies since initial message
+        if check_reply(row[COL_PHONE], row[COL_MSG_ID], row[COL_INIT_TS]):
+            LOG.info(
+                "Auto-detected reply for row %s (msg_id=%s)",
+                sheet_row,
+                row[COL_MSG_ID],
+            )
+            mark_reply(sheet_row)
+            continue
+
         try:
             ts = datetime.fromisoformat(row[COL_INIT_TS])
             if ts.tzinfo is None:


### PR DESCRIPTION
## Summary
- detect SMS replies automatically during follow-up check
- log when an automatic reply is detected and mark it in the sheet

## Testing
- `python -m py_compile bot_min.py`

------
https://chatgpt.com/codex/tasks/task_e_686c19b54580832aa1b3b767d06e4082