### PR TITLE
Add expanded toll-free area code filter

### DIFF
--- a/bot_min.py
+++ b/bot_min.py
@@ -119,7 +119,15 @@ LABEL_TABLE = {
 LABEL_RE      = re.compile("(" + "|".join(map(re.escape, LABEL_TABLE)) + ")", re.I)
 US_AREA_CODES = {str(i) for i in range(201, 990)}
 OFFICE_HINTS  = {"office", "main", "fax", "team", "brokerage", "corporate"}
-BAD_AREA      = {"800", "866"}
+BAD_AREA      = {
+    "800",
+    "888",
+    "877",
+    "866",
+    "855",
+    "844",
+    "833",
+}
 
 # ───────────────────── Google / Sheets setup ─────────────────────
 creds           = Credentials.from_service_account_info(SC_JSON, scopes=SCOPES)

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -80,7 +80,15 @@ def _digits_only(num: str) -> str:
     return digits
 
 
-BAD_AREA = {"800", "866"}  # reject toll-free & 1xx after leading '1' stripped
+BAD_AREA = {
+    "800",
+    "888",
+    "877",
+    "866",
+    "855",
+    "844",
+    "833",
+}  # reject toll-free & 1xx after leading '1' stripped
 
 def fmt_phone(raw: str) -> str:
     """Return 123-456-7890 or '' if invalid/toll-free/1xx."""


### PR DESCRIPTION
## Summary
- update `BAD_AREA` constants to ignore more toll-free area codes in `bot_min.py` and `webhook_server.py`

## Testing
- `python -m py_compile bot_min.py webhook_server.py`

------
https://chatgpt.com/codex/tasks/task_e_687593eda3ec832a8330e87acc067ec5