### PR TITLE
Handle Cloudmersive lookup failures

### DIFF
--- a/bot_min.py
+++ b/bot_min.py
@@ -947,8 +947,10 @@ def is_mobile_number(phone: str) -> bool:
             or "mobile" in str(data.get("LineType", "")).lower()
         )
     except Exception as exc:
-        LOG.warning("Cloudmersive lookup failed for %s (%s)", phone, exc)
-        is_mobile = False
+        LOG.warning(
+            "Cloudmersive lookup failed for %s (%s) – assuming mobile", phone, exc
+        )
+        return True
     _line_type_cache[phone] = is_mobile
     return is_mobile
 


### PR DESCRIPTION
## Summary
- treat Cloudmersive errors as unknown
- avoid caching failure result

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c0da4d52c832a94be258783bc534d