### PR TITLE
loosen phone requirement when mobile check fails

### DIFF
--- a/bot_min.py
+++ b/bot_min.py
@@ -720,6 +720,16 @@ def lookup_phone(agent: str, state: str, row_payload: Dict[str, Any]) -> str:
             if is_mobile_number(cand):
                 phone = cand
                 break
+    # If no candidate passed the mobile check, fall back to the highest scored
+    # number. Cloudmersive occasionally misclassifies mobile lines and leaving
+    # the phone field blank is less helpful than a best guess.
+    if not phone:
+        if cand_good:
+            phone = max(cand_good.items(), key=lambda t: t[1])[0]
+            LOG.debug("PHONE FALLBACK using unverified number %s", phone)
+        elif cand_office:
+            phone = max(cand_office.items(), key=lambda t: t[1])[0]
+            LOG.debug("PHONE FALLBACK using office number %s", phone)
     cache_p[key] = phone or ""
     if phone:
         LOG.debug("PHONE WIN %s via %s", phone, src_good.get(phone, "crawler/unverified"))


### PR DESCRIPTION
## Summary
- fall back to highest scored phone number even if mobile check fails

## Testing
- `python -m py_compile bot_min.py`
- `python -m py_compile apify_fetcher.py bot.py bot_legacy_202505141940.py poller.py webhook_server.py` *(fails: SyntaxError in bot.py)*

------
https://chatgpt.com/codex/tasks/task_e_688277a593fc832ab89c969572a3de1b