### PR TITLE
Fix mobile detection logic

### DIFF
--- a/bot_min.py
+++ b/bot_min.py
@@ -959,7 +959,7 @@ def is_mobile_number(phone: str) -> bool:
         )
         is_mobile = bool(
             data.get("IsMobile")
-            or data.get("PhoneNumberType", "").lower() == "mobile"
+            or "mobile" in data.get("PhoneNumberType", "").lower()
             or "mobile" in str(data.get("LineType", "")).lower()
         )
         LOG.debug("Cloudmersive classified %s as mobile=%s", digits, is_mobile)


### PR DESCRIPTION
## Summary
- expand substring matching for mobile numbers when using the Cloudmersive API

## Testing
- `python -m py_compile bot_min.py`

------
https://chatgpt.com/codex/tasks/task_e_688289a2e834832aa65e6cc5c2a4856d