### PR TITLE
Handle explicit non-short-sale listings

### DIFF
--- a/bot_min.py
+++ b/bot_min.py
@@ -103,7 +103,10 @@ LOG = logging.getLogger("bot_min")
 
 # ───────────────────── regexes & misc helpers ─────────────────────
 SHORT_RE = re.compile(r"\bshort\s+sale\b", re.I)
-BAD_RE   = re.compile(r"\b(?:approved short sale|short sale approved)\b", re.I)
+BAD_RE   = re.compile(
+    r"\b(?:approved short sale|short sale approved|not a\s+short\s+sale)\b",
+    re.I,
+)
 TEAM_RE  = re.compile(r"^\s*the\b|\bteam\b", re.I)
 IMG_EXT  = (".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp")
 PHONE_RE = re.compile(

--- a/process_rows
+++ b/process_rows
@@ -16,12 +16,15 @@ Google Sheet:
 https://docs.google.com/spreadsheets/d/12UzsoQCo4W0WB_lNl3BjKpQ_wXNhEH7xegkFRVu2M70
 """
 
-import os, json, html, textwrap, datetime, sqlite3, requests
+import os, json, html, textwrap, datetime, sqlite3, requests, re
 from pathlib import Path
 
 import openai
 import gspread
 from oauth2client.service_account import ServiceAccountCredentials
+
+# Phrase indicating the property is explicitly *not* a short sale
+NOT_SHORT_RE = re.compile(r"not a\s+short\s+sale", re.I)
 
 # ------------------  load secrets  ------------------
 openai.api_key = os.environ["OPENAI_API_KEY"]
@@ -76,6 +79,9 @@ differs."""
 
 
 def gpt_is_short_sale(description: str) -> bool:
+    if NOT_SHORT_RE.search(description or ""):
+        return False
+
     prompt = (
         "Return YES if the following home listing text indicates the 
 property is a short sale "


### PR DESCRIPTION
## Summary
- expand BAD_RE regex to detect "not a short sale"
- ignore descriptions containing "not a short sale" before calling GPT
- add NOT_SHORT_RE constant and early check in `process_rows`

## Testing
- `python -m py_compile bot_min.py`

------
https://chatgpt.com/codex/tasks/task_e_688a1f60966c832aa2465428080bdfaf