### PR TITLE
Refine weekend scheduling for follow‑ups

### DIFF
--- a/bot_min.py
+++ b/bot_min.py
@@ -1251,14 +1251,15 @@ if __name__ == "__main__":
         while True:
             now = datetime.now(tz=TZ)
             hour = now.hour
-            if _is_weekend(now):
-                LOG.info("Weekend; skipping follow-up pass")
-            elif WORK_START <= hour < WORK_END:
-                LOG.info("Starting follow‑up pass at %s", now.isoformat())
-                try:
-                    _follow_up_pass()
-                except Exception as e:
-                    LOG.error("Error during follow-up pass: %s", e)
+            if WORK_START <= hour < WORK_END:
+                if _is_weekend(now):
+                    LOG.info("Weekend; skipping follow-up pass")
+                else:
+                    LOG.info("Starting follow‑up pass at %s", now.isoformat())
+                    try:
+                        _follow_up_pass()
+                    except Exception as e:
+                        LOG.error("Error during follow-up pass: %s", e)
             else:
                 LOG.info(
                     "Current hour %s outside work hours (%s–%s); skipping follow‑up",


### PR DESCRIPTION
## Summary
- Allow hourly loop to run 7 days a week from 8 am to 8 pm
- Skip follow-up processing on weekends while continuing regular scraping hours

## Testing
- `python -m py_compile bot_min.py`


------
https://chatgpt.com/codex/tasks/task_e_6899144c857c832a89b1ddccabd62fcf