### PR TITLE
Reduce Apify usage via caching and incremental fetch

### DIFF
--- a/apify_fetcher.py
+++ b/apify_fetcher.py
@@ -1,4 +1,6 @@
 import os
+import json
+from pathlib import Path
 import requests
 from dotenv import load_dotenv
 
@@ -9,13 +11,40 @@ load_dotenv()
 APIFY_TOKEN = os.getenv("APIFY_TOKEN")
 HEADERS = {"Authorization": f"Bearer {APIFY_TOKEN}"} if APIFY_TOKEN else {}
 
+# Track how many items we've already pulled for each dataset so we only
+# request newly appended rows on subsequent runs.
+PROGRESS_FILE = Path("dataset_progress.json")
+
+
 def fetch_rows(dataset_id: str) -> list[dict]:
+    """Fetch only new items from an Apify dataset.
+
+    The number of items already retrieved is stored in ``dataset_progress.json``
+    keyed by dataset_id. On each call we request items starting at that offset
+    and update the stored offset so the next call only pulls freshly appended
+    records.
     """
-    Fetch all items from an Apify dataset.
-    """
+
+    # load previous offsets
+    progress = {}
+    if PROGRESS_FILE.exists():
+        try:
+            progress = json.loads(PROGRESS_FILE.read_text())
+        except Exception:
+            progress = {}
+
+    offset = progress.get(dataset_id, 0)
+
     url = f"https://api.apify.com/v2/datasets/{dataset_id}/items"
-    params = {"format": "json", "clean": 1}
+    params = {"format": "json", "clean": 1, "offset": offset}
     response = requests.get(url, params=params, headers=HEADERS)
     response.raise_for_status()
-    return response.json()
+    items = response.json()
+
+    # persist new offset so next call only fetches subsequent rows
+    if items:
+        progress[dataset_id] = offset + len(items)
+        PROGRESS_FILE.write_text(json.dumps(progress))
+
+    return items
 

--- a/process_rows
+++ b/process_rows
@@ -16,7 +16,7 @@ Google Sheet:
 https://docs.google.com/spreadsheets/d/12UzsoQCo4W0WB_lNl3BjKpQ_wXNhEH7xegkFRVu2M70
 """
 
-import os, json, html, textwrap, datetime, sqlite3, requests, re
+import os, json, html, textwrap, datetime, sqlite3, requests, re, time
 from pathlib import Path
 
 import openai
@@ -33,31 +33,32 @@ SMS_KEY        = os.environ["SMSMOBILE_API_KEY"]
 SMS_FROM       = os.environ["SMSMOBILE_FROM"]
 
 # optional – write service‑account json from env‑var
-if "GOOGLE_SVC_JSON" in os.environ and not 
-Path("service_account.json").exists():
-    Path("service_account.json").write_text(os.environ["GOOGLE_SVC_JSON"], 
-encoding="utf‑8")
+if "GOOGLE_SVC_JSON" in os.environ and not Path("service_account.json").exists():
+    Path("service_account.json").write_text(
+        os.environ["GOOGLE_SVC_JSON"], encoding="utf-8"
+    )
 
 # ------------------  Google Sheets ------------------
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
-creds = 
-ServiceAccountCredentials.from_json_keyfile_name("service_account.json", 
-SCOPES)
+creds = ServiceAccountCredentials.from_json_keyfile_name("service_account.json", SCOPES)
 client = gspread.authorize(creds)
-SHEET = 
-client.open_by_key("12UzsoQCo4W0WB_lNl3BjKpQ_wXNhEH7xegkFRVu2M70").sheet1
+SHEET = client.open_by_key("12UzsoQCo4W0WB_lNl3BjKpQ_wXNhEH7xegkFRVu2M70").sheet1
 
 # ------------------  local dedupe DB ------------------
 conn = sqlite3.connect("seen.db")
 conn.execute("CREATE TABLE IF NOT EXISTS listings (zpid TEXT PRIMARY KEY)")
 conn.commit()
 
-# Cache previously looked-up contacts to reduce Apify calls
+# Cache previously looked-up contacts to reduce Apify calls. Retain entries for a long time
+# since agent contact info rarely changes.
 cache = sqlite3.connect("contact_cache.db")
 cache.execute(
-    "CREATE TABLE IF NOT EXISTS contacts (agent TEXT, state TEXT, phone TEXT, email TEXT, PRIMARY KEY(agent, state))"
+    "CREATE TABLE IF NOT EXISTS contacts (agent TEXT, state TEXT, phone TEXT, email TEXT, last_seen REAL, PRIMARY KEY(agent, state))"
 )
 cache.commit()
+
+# how long to trust cached contact info (seconds)
+CONTACT_TTL = 60 * 60 * 24 * 365  # 1 year
 
 # ------------------  utility funcs ------------------
 
@@ -83,10 +84,9 @@ def gpt_is_short_sale(description: str) -> bool:
         return False
 
     prompt = (
-        "Return YES if the following home listing text indicates the 
-property is a short sale "
-        "and NOT already approved or marked 'not a short sale'. Otherwise 
-return NO.\n\n"
+        "Return YES if the following home listing text indicates the "
+        "property is a short sale "
+        "and NOT already approved or marked 'not a short sale'. Otherwise return NO.\n\n"
         f"Listing text:\n{description[:3500]}"
     )
     resp = openai.chat.completions.create(
@@ -154,10 +154,10 @@ def find_contact(row: dict):
     state = address.split(",")[-2].strip().split()[0] if "," in address else ""
 
     cached = cache.execute(
-        "SELECT phone, email FROM contacts WHERE agent=? AND state=?",
+        "SELECT phone, email, last_seen FROM contacts WHERE agent=? AND state=?",
         (agent, state),
     ).fetchone()
-    if cached:
+    if cached and (time.time() - cached[2] < CONTACT_TTL):
         return cached[0], cached[1]
 
     query = f'"{agent}" real estate {state} phone'
@@ -170,8 +170,8 @@ def find_contact(row: dict):
         phone, email = _extract_with_gpt(link, html_text)
         if phone or email:
             cache.execute(
-                "INSERT OR REPLACE INTO contacts (agent, state, phone, email) VALUES (?,?,?,?)",
-                (agent, state, phone or "", email or ""),
+                "INSERT OR REPLACE INTO contacts (agent, state, phone, email, last_seen) VALUES (?,?,?,?,?)",
+                (agent, state, phone or "", email or "", time.time()),
             )
             cache.commit()
             return phone, email
@@ -209,8 +209,10 @@ def process_rows(rows: list[dict]):
         ])
 
         # send SMS
-        sms_body = f"Hi {row.get('agentName','there')}, I saw your 
-short‑sale at {row.get('address')}. Are you open to discussing?"
+        sms_body = (
+            f"Hi {row.get('agentName','there')}, I saw your short-sale at {row.get('address')}. "
+            "Are you open to discussing?"
+        )
         try:
             send_sms(phone, sms_body)
             print("Contacted", phone, row.get("address"))


### PR DESCRIPTION
## Summary
- fetch only newly appended items from Apify datasets and track progress locally
- cache agent contacts with a 1-year TTL to avoid repeated lookups
- de-duplicate webhook rows against stored ZPIDs before processing

## Testing
- `python -m py_compile apify_fetcher.py process_rows webhook_server.py`


------
https://chatgpt.com/codex/tasks/task_e_689a7968f25c832a8713778247e18a64