### PR TITLE
Dispose BeautifulSoup objects to free memory

### DIFF
--- a/bot_min.py
+++ b/bot_min.py
@@ -511,6 +511,7 @@ def extract_struct(td: str) -> Tuple[List[str], List[str]]:
         phones.append(fmt_phone(a["href"].split("tel:")[-1]))
     for a in soup.select('a[href^="mailto:"]'):
         mails.append(clean_email(a["href"].split("mailto:")[-1]))
+    soup.decompose()
     return phones, mails
 
 def proximity_scan(t: str, first_name: str = "", last_name: str = ""):

--- a/process_rows
+++ b/process_rows
@@ -177,7 +177,7 @@ def _parse_detail_contact(url: str):
         m = EMAIL_RE.search(text)
         if m:
             email = m.group(0)
-
+    soup.decompose()
     return phone, email
 
 


### PR DESCRIPTION
## Summary
- Ensure `_parse_detail_contact` frees BeautifulSoup parse tree after extraction
- Release BeautifulSoup objects in `extract_struct` to avoid lingering DOM trees

## Testing
- `python -m py_compile process_rows bot_min.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f8755ef18832a8dbd04fd99371509