### PR TITLE
Use Google Custom Search API in bot_min

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@ SMS sending is pluggable. Set the provider in `config.json` (`sms_provider`) or 
   * Requires `smsmobile_api_key`/`smsmobile_from` or env vars `SMSMOBILE_API_KEY` and `SMSMOBILE_FROM`.
 
 Switching providers is as simple as updating the config or environment and restarting the bot.
+
+## Google Custom Search
+
+Agent contact details are looked up using the Google Custom Search API. Provide credentials via environment variables:
+
+* `CS_API_KEY` or `GOOGLE_API_KEY` – your Google API key
+* `CS_CX` or `GOOGLE_CX` – the Custom Search Engine ID
+
+With these variables set, the bot queries Google directly instead of relying on Apify for search results.

--- a/bot_min.py
+++ b/bot_min.py
@@ -30,8 +30,10 @@ except ImportError:
     BeautifulSoup = None
 
 # ───────────────────── configuration & constants ─────────────────────
-CS_API_KEY     = os.environ["CS_API_KEY"]
-CS_CX          = os.environ["CS_CX"]
+# Google Custom Search credentials. Prefer CS_* names but fall back to
+# GOOGLE_API_KEY / GOOGLE_CX if provided.
+CS_API_KEY     = os.getenv("CS_API_KEY") or os.environ["GOOGLE_API_KEY"]
+CS_CX          = os.getenv("CS_CX") or os.environ["GOOGLE_CX"]
 GSHEET_ID      = os.environ["GSHEET_ID"]
 SC_JSON        = json.loads(os.environ["GCP_SERVICE_ACCOUNT_JSON"])
 SCOPES         = ["https://www.googleapis.com/auth/spreadsheets"]
@@ -1223,7 +1225,7 @@ if __name__ == "__main__":
 
     if payload and payload.get("listings"):
         LOG.info(
-            "apify-hook: received %s listings directly in payload",
+            "received %s listings directly in payload",
             len(payload["listings"])
         )
         process_rows(payload["listings"])


### PR DESCRIPTION
## Summary
- Read Google Custom Search credentials (CS_API_KEY/CS_CX or GOOGLE_API_KEY/GOOGLE_CX) for agent lookups
- Remove residual Apify references and document required Google API keys

## Testing
- `CS_API_KEY=dummy CS_CX=dummy python -m py_compile bot_min.py`
- `CS_API_KEY=dummy CS_CX=dummy python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae3503ce74832abacaf1fa3fdef4bf