### PR TITLE
Fix SMS sending to use SMS Gateway for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,9 @@
 
 This repository contains scripts for scraping Zillow short sale listings and contacting agents via SMS or email.
 
-## SMS Providers
+## SMS
 
-SMS sending is pluggable. Set the provider in `config.json` (`sms_provider`) or with the `SMS_PROVIDER` environment variable.
-
-* `android_gateway` (default) — uses [SMS Gateway for Android](https://api.smstext.app).
-  * Requires `sms_gateway_api_key` or `SMS_GATEWAY_API_KEY` env var.
-* `smsmobile` — uses the SMSMobile API.
-  * Requires `smsmobile_api_key`/`smsmobile_from` or env vars `SMSMOBILE_API_KEY` and `SMSMOBILE_FROM`.
-
-Switching providers is as simple as updating the config or environment and restarting the bot.
+SMS sending uses [SMS Gateway for Android](https://api.smstext.app).  Provide the API key via the `sms_gateway_api_key` field in `config.json` or the `SMS_GATEWAY_API_KEY` environment variable.  The provider can be set with `sms_provider`, but currently only `android_gateway` is supported.
 
 ## Google Custom Search
 

--- a/bot.py
+++ b/bot.py
@@ -22,10 +22,8 @@ ua = UserAgent()
 GOOGLE_API_KEY = CFG.get("google_api_key")
 GOOGLE_CX = CFG.get("google_cx")
 
-# expose SMS credentials for provider abstraction
+# expose SMS Gateway credentials
 os.environ.setdefault("SMS_GATEWAY_API_KEY", CFG.get("sms_gateway_api_key", ""))
-os.environ.setdefault("SMSMOBILE_API_KEY", CFG.get("smsmobile_api_key", ""))
-os.environ.setdefault("SMSMOBILE_FROM", CFG.get("smsmobile_from", ""))
 
 # ---------- 1. ZILLOW HELPERS ----------
 def z_get(url: str) -> requests.Response:
@@ -411,7 +409,7 @@ def run_cycle() -> None:
 
         sms_text = CFG["sms_template"].format(first=first, address=street)
         try:
-            sms.send_sms(phone, sms_text)
+            sms.send(phone, sms_text)
             print("SMS sent to", first, phone)
         except Exception as e:
             print("SMS error:", e)

--- a/config.json
+++ b/config.json
@@ -30,7 +30,5 @@
   "smtp_user": "ygkutler@gmail.com",
   "smtp_pass": "lufh plnx gcdu myou",
   "sms_provider": "android_gateway",
-  "sms_gateway_api_key": "",
-  "smsmobile_api_key": "",
-  "smsmobile_from": ""
+  "sms_gateway_api_key": ""
 }

--- a/process_rows
+++ b/process_rows
@@ -1,20 +1,18 @@
 """Zillow short‑sale pipeline.
-Receives rows from Apify webhook, filters with GPT, looks up agent 
+Receives rows from Apify webhook, filters with GPT, looks up agent
 phone/email
-via Google‑search + GPT, writes Google Sheet, sends SMS through SMSmobile.
-All secrets are read from environment variables set in Render.
+via Google‑search + GPT, writes Google Sheet, sends SMS through SMS Gateway
+for Android. All secrets are read from environment variables set in Render.
 
 Required env‑vars (Render → Environment tab for Web‑Service **and** Cron
 Job):
   OPENAI_API_KEY       – OpenAI secret key
   APIFY_API_TOKEN      – Apify token
-  SMS_PROVIDER         – 'android_gateway' (default) or 'smsmobile'
-  SMS_GATEWAY_API_KEY  – API key for SMS Gateway for Android (if used)
-  SMSMOBILE_API_KEY    – SMSmobile key (if used)
-  SMSMOBILE_FROM       – sender ID/phone as registered with SMSmobile
+  SMS_PROVIDER         – currently only 'android_gateway'
+  SMS_GATEWAY_API_KEY  – API key for SMS Gateway for Android
   GOOGLE_SVC_JSON      – (optional) entire JSON for service‑account
 
-Google Sheet: 
+Google Sheet:
 https://docs.google.com/spreadsheets/d/12UzsoQCo4W0WB_lNl3BjKpQ_wXNhEH7xegkFRVu2M70
 """
 

--- a/sms_providers.py
+++ b/sms_providers.py
@@ -1,6 +1,5 @@
 import os
 import base64
-import re
 from typing import Optional
 
 import requests
@@ -23,42 +22,8 @@ class SMSGatewayForAndroid:
         return None
 
 
-class SMSMobileSender:
-    """Sender for SMSMobile API."""
-
-    def __init__(self, api_key: str, from_: str, url: str = "https://api.smsmobileapi.com/sendsms/"):
-        self.api_key = api_key
-        self.from_ = from_
-        self.url = url
-
-    def send(self, to: str, message: str) -> Optional[str]:
-        digits = re.sub(r"\D", "", to)
-        payload = {
-            "apikey": self.api_key,
-            "recipients": digits,
-            "message": message,
-            "sendsms": "1",
-        }
-        if self.from_:
-            payload["from"] = self.from_
-        r = requests.post(self.url, timeout=15, data=payload)
-        r.raise_for_status()
-        data = {}
-        try:
-            data = r.json().get("result", {})
-        except Exception:
-            pass
-        if str(data.get("error")) != "0":
-            raise RuntimeError(f"SMSMobile error: {data}")
-        return data.get("message_id")
-
-
 def get_sender(provider: Optional[str] = None):
-    """Return an SMS sender for *provider* (default android_gateway)."""
-    prov = (provider or os.getenv("SMS_PROVIDER") or "android_gateway").lower()
-    if prov == "smsmobile":
-        key = os.getenv("SMSMOBILE_API_KEY", "")
-        frm = os.getenv("SMSMOBILE_FROM", "")
-        return SMSMobileSender(api_key=key, from_=frm)
+    """Return an SMS sender (currently only SMS Gateway for Android)."""
+    # provider parameter is kept for backward compatibility but ignored
     key = os.getenv("SMS_GATEWAY_API_KEY", "")
     return SMSGatewayForAndroid(api_key=key)


### PR DESCRIPTION
## Summary
- remove legacy SMSMobile provider and simplify SMS handling
- switch bot to call `send` on SMSGateway sender
- update docs and config for SMS Gateway only

## Testing
- `python -m py_compile bot.py sms_providers.py process_rows poller.py`


------
https://chatgpt.com/codex/tasks/task_e_68b055044b48832ab95b37b2a3a6bdf3