### PR TITLE
Enable SMS Gateway by default

### DIFF
--- a/bot_min.py
+++ b/bot_min.py
@@ -48,7 +48,12 @@ FU_LOOKBACK_ROWS = int(os.getenv("FU_LOOKBACK_ROWS", "50"))
 WORK_START     = int(os.getenv("WORK_START_HOUR", "8"))   # inclusive (8 am)
 WORK_END       = int(os.getenv("WORK_END_HOUR", "21"))    # exclusive (pauses at 9 pm)
 
-SMS_ENABLE        = os.getenv("SMS_ENABLE", "false").lower() == "true"
+_sms_enable_env = os.getenv("SMS_ENABLE")
+if _sms_enable_env is None:
+    # Enable SMS by default when any SMS API key is present
+    SMS_ENABLE = bool(os.getenv("SMS_GATEWAY_API_KEY") or os.getenv("SMS_API_KEY"))
+else:
+    SMS_ENABLE = _sms_enable_env.lower() == "true"
 SMS_TEST_MODE     = os.getenv("SMS_TEST_MODE", "true").lower() == "true"
 SMS_TEST_NUMBER   = os.getenv("SMS_TEST_NUMBER", "")
 SMS_PROVIDER      = os.getenv("SMS_PROVIDER", "android_gateway")
@@ -1010,6 +1015,7 @@ def send_sms(
     follow_up: bool = False,
 ):
     if not SMS_ENABLE or not phone:
+        LOG.debug("SMS disabled or missing phone; skipping send to %s", phone)
         return
     if SMS_TEST_MODE and SMS_TEST_NUMBER:
         phone = SMS_TEST_NUMBER

--- a/sms_providers.py
+++ b/sms_providers.py
@@ -25,5 +25,5 @@ class SMSGatewayForAndroid:
 def get_sender(provider: Optional[str] = None):
     """Return an SMS sender (currently only SMS Gateway for Android)."""
     # provider parameter is kept for backward compatibility but ignored
-    key = os.getenv("SMS_GATEWAY_API_KEY", "")
+    key = os.getenv("SMS_GATEWAY_API_KEY") or os.getenv("SMS_API_KEY", "")
     return SMSGatewayForAndroid(api_key=key)


### PR DESCRIPTION
## Summary
- Enable SMS sending automatically when an SMS API key is present.
- Fallback to legacy `SMS_API_KEY` and log when SMS delivery is skipped.

## Testing
- `python -m py_compile bot_min.py sms_providers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b07f113d9c832a9310cce331177c56