### PR TITLE
Prevent duplicate scheduler startup and overlapping follow-up passes

### DIFF
--- a/bot_min.py
+++ b/bot_min.py
@@ -12140,6 +12140,9 @@ def _within_scheduler_hours(slot: datetime) -> bool:
     return WORK_START <= slot.hour < WORK_END
 
 
+_follow_up_pass_lock = threading.Lock()
+
+
 def _next_work_start(slot: datetime, *, include_weekends: bool) -> datetime:
     slot = slot.astimezone(SCHEDULER_TZ)
     candidate = slot
@@ -12190,10 +12193,15 @@ def _run_hourly_cycle(
 
     if _within_work_hours(run_time):
         LOG.info("Starting follow-up pass at %s", run_time.isoformat())
-        try:
-            _follow_up_pass()
-        except Exception as exc:
-            LOG.exception("Error during follow-up pass: %s", exc)
+        if not _follow_up_pass_lock.acquire(blocking=False):
+            LOG.info("follow-up: skipped overlapping pass")
+        else:
+            try:
+                _follow_up_pass()
+            except Exception as exc:
+                LOG.exception("Error during follow-up pass: %s", exc)
+            finally:
+                _follow_up_pass_lock.release()
     else:
         LOG.info(
             "Current hour %s outside work hours (%s–%s); skipping follow-up",
@@ -12353,6 +12361,7 @@ def _current_sheet_phone_for_row(row_idx: int) -> str:
 
 
 def _follow_up_pass():
+    LOG.info("follow-up: using bounded init_ts scan path")
     now = datetime.now(tz=SCHEDULER_TZ)
     max_row = max(1, int(getattr(ws, "row_count", 1) or 1))
     if max_row <= 1:

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -87,6 +87,8 @@ EXPORTED_ZPIDS: set[str] = set()
 
 _scheduler_thread: Optional[threading.Thread] = None
 _scheduler_stop: Optional[threading.Event] = None
+_scheduler_start_lock = threading.Lock()
+_scheduler_started = False
 _keepalive_thread: Optional[threading.Thread] = None
 _keepalive_stop: Optional[threading.Event] = None
 _deferred_rows_lock = threading.Lock()
@@ -294,37 +296,44 @@ def _ensure_scheduler_thread(
     *,
     initial_callbacks: bool = True,
 ) -> None:
-    global _scheduler_thread, _scheduler_stop
-    if _scheduler_thread and _scheduler_thread.is_alive():
-        return
+    global _scheduler_thread, _scheduler_stop, _scheduler_started
+    with _scheduler_start_lock:
+        if _scheduler_started:
+            logger.info("scheduler already started")
+            return
+        if _scheduler_thread and _scheduler_thread.is_alive():
+            _scheduler_started = True
+            logger.info("scheduler already started")
+            return
 
-    _scheduler_stop = threading.Event()
+        _scheduler_stop = threading.Event()
 
-    def _runner() -> None:
-        logger.info("Background hourly scheduler thread starting")
-        while not _scheduler_stop.is_set():
-            try:
-                run_hourly_scheduler(
-                    stop_event=_scheduler_stop,
-                    hourly_callbacks=hourly_callbacks,
-                    run_immediately=_should_run_immediately(),
-                    initial_callbacks=initial_callbacks,
-                )
-                break
-            except Exception:
-                logger.exception(
-                    "Background scheduler crashed; restarting in 30 seconds"
-                )
-                if _scheduler_stop.wait(30):
+        def _runner() -> None:
+            logger.info("Background hourly scheduler thread starting")
+            while not _scheduler_stop.is_set():
+                try:
+                    run_hourly_scheduler(
+                        stop_event=_scheduler_stop,
+                        hourly_callbacks=hourly_callbacks,
+                        run_immediately=_should_run_immediately(),
+                        initial_callbacks=initial_callbacks,
+                    )
                     break
-        logger.info("Background hourly scheduler thread stopped")
+                except Exception:
+                    logger.exception(
+                        "Background scheduler crashed; restarting in 30 seconds"
+                    )
+                    if _scheduler_stop.wait(30):
+                        break
+            logger.info("Background hourly scheduler thread stopped")
 
-    _scheduler_thread = threading.Thread(
-        target=_runner,
-        name="hourly-scheduler",
-        daemon=True,
-    )
-    _scheduler_thread.start()
+        _scheduler_thread = threading.Thread(
+            target=_runner,
+            name="hourly-scheduler",
+            daemon=True,
+        )
+        _scheduler_thread.start()
+        _scheduler_started = True
 
 
 def _ensure_keepalive_thread() -> None:
@@ -927,11 +936,15 @@ async def _start_scheduler() -> None:
 
 @app.on_event("shutdown")
 async def _stop_scheduler() -> None:
-    global _scheduler_thread, _scheduler_stop
+    global _scheduler_thread, _scheduler_stop, _scheduler_started
     if _scheduler_stop:
         _scheduler_stop.set()
     if _scheduler_thread and _scheduler_thread.is_alive():
         _scheduler_thread.join(timeout=10)
+    with _scheduler_start_lock:
+        _scheduler_started = False
+        _scheduler_thread = None
+        _scheduler_stop = None
     global _keepalive_thread, _keepalive_stop
     if _keepalive_stop:
         _keepalive_stop.set()


### PR DESCRIPTION
### Motivation
- Prevent the hourly scheduler loop from being started more than once in a single process which was producing duplicate "Scheduler wake" / "Starting follow-up pass" lines and triggering overlapping sheet scans and memory spikes. 
- Keep follow-up behavior identical while ensuring only one follow-up pass can run at a time to avoid concurrent, memory-heavy work.

### Description
- Added a process-wide scheduler startup guard in `webhook_server.py` using `_scheduler_start_lock` and `_scheduler_started` so `_ensure_scheduler_thread()` returns early and logs `scheduler already started` on duplicate startup attempts (file changed: `webhook_server.py`).
- Reset the scheduler-start guard and clear thread/event references during shutdown to keep the lifecycle clean (file changed: `webhook_server.py`).
- Added a non-blocking per-process lock ` _follow_up_pass_lock = threading.Lock()` in `bot_min.py`, and wrapped follow-up invocation with a `acquire(blocking=False)` so overlapping follow-up runs are skipped and log `follow-up: skipped overlapping pass` (file changed: `bot_min.py`).
- Added a concise follow-up path log `follow-up: using bounded init_ts scan path` inside `_follow_up_pass()` to make the active scan strategy explicit and confirm we are using the bounded init_ts flow; no follow-up business logic or selection criteria were changed (file changed: `bot_min.py`).

### Testing
- Ran Python compilation on modified modules with `python -m py_compile bot_min.py webhook_server.py` which succeeded.
- Ran the narrow unit tests for follow-up behavior with `pytest -q tests/test_followup_phone_refresh.py` which produced 2 passed and 1 failed; the failing assertion was in the test fixture capturing send behavior and appears unrelated to the scheduler/startup guard logic.  
- No broader functional or end-to-end test suite was run as requested to keep validation narrow and safe.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e259b849c0832a90ba8c45e664ac4a)